### PR TITLE
Fixing wrong xml attribute in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In the view system, use [`ChartView`](https://vico.patrykandpatryk.com/vico/view
     android:id="@+id/chart"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    app:chartType="column"
+    app:chart="column"
     app:showBottomAxis="true"
     app:showStartAxis="true" />
 ```


### PR DESCRIPTION
replacing 
```xml 
app:chartType="column"
```
with

```xml
app:chart="column"
```

using app:chartType="column" will produce an error and in the sample app you use app:chart="column"