### PR TITLE
#95 Improve chart scaling logic

### DIFF
--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/draw/ChartDrawContextExtensions.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/draw/ChartDrawContextExtensions.kt
@@ -24,8 +24,6 @@ import com.patrykandpatryk.vico.core.context.DrawContext
 import com.patrykandpatryk.vico.core.context.MeasureContext
 import com.patrykandpatryk.vico.core.model.Point
 
-private const val DEFAULT_SCALE = 1f
-
 /**
  * The anonymous implementation of [ChartDrawContext].
  *
@@ -72,10 +70,8 @@ public fun chartDrawContext(
         if (isHorizontalScrollEnabled) {
             measureContext.chartScale
         } else {
-            (
-                chartBounds.width() /
-                    (segmentProperties.segmentWidth * chartValuesManager.getChartValues().getDrawnEntryCount())
-                ).coerceAtMost(DEFAULT_SCALE)
+            chartBounds.width() /
+                (segmentProperties.segmentWidth * chartValuesManager.getChartValues().getDrawnEntryCount())
         }
 }
 


### PR DESCRIPTION
Enable scaling the chart up (e.g. increasing column and spacing width in `ColumnChart`) when horizontal scrolling is disabled, and chart entries don’t fill the whole available width.

|![image](https://user-images.githubusercontent.com/14221573/174265834-9d0c5beb-d41e-4a3a-86ed-31c35521f5bf.png)|
|:--:|
|*Before*|

|![image](https://user-images.githubusercontent.com/14221573/174265634-de05b2e0-3bf0-48ba-8755-4a499e05ab74.png)|
|:--:|
|*After*|

|![image](https://user-images.githubusercontent.com/14221573/174265124-365ed7bb-3200-4b1e-be58-088eab39e62d.png)|
|:--:|
|*After, with `Chart.maxX` set to `5f`*|