### PR TITLE
Update RandomEntriesGenerator

### DIFF
--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/Home.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/Home.kt
@@ -58,6 +58,7 @@ internal fun Home() {
     val showcaseViewModel = viewModel<ShowcaseViewModel>()
     val sampleCharts = getSampleCharts(
         chartEntryModelProducer = showcaseViewModel.chartEntryModelProducer,
+        chartStepEntryModelProducer = showcaseViewModel.chartStepEntryModelProducer,
         composedChartEntryModelProducer = showcaseViewModel.composedChartEntryModelProducer,
         multiChartEntryModelProducer = showcaseViewModel.multiChartEntryModelProducer,
     ).remember()

--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/util/GetSampleCharts.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/util/GetSampleCharts.kt
@@ -37,14 +37,15 @@ import com.patrykandpatryk.vico.sample.chart.ViewStackedColumnChart
 
 internal fun getSampleCharts(
     chartEntryModelProducer: ChartEntryModelProducer,
+    chartStepEntryModelProducer: ChartEntryModelProducer,
     multiChartEntryModelProducer: ChartEntryModelProducer,
     composedChartEntryModelProducer: ComposedChartEntryModelProducer<ChartEntryModel>,
 ) = listOf(
     SampleChart(
         labelResourceId = R.string.line_chart_label,
         descriptionResourceId = R.string.line_chart_description,
-        composeBased = { ComposeLineChart(chartEntryModelProducer = chartEntryModelProducer) },
-        viewBased = { ViewLineChart(chartEntryModelProducer = chartEntryModelProducer) },
+        composeBased = { ComposeLineChart(chartEntryModelProducer = chartStepEntryModelProducer) },
+        viewBased = { ViewLineChart(chartEntryModelProducer = chartStepEntryModelProducer) },
     ),
     SampleChart(
         labelResourceId = R.string.column_chart_label,

--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/viewmodel/ShowcaseViewModel.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/viewmodel/ShowcaseViewModel.kt
@@ -40,7 +40,14 @@ internal class ShowcaseViewModel : ViewModel() {
         yRange = GENERATOR_Y_RANGE_BOTTOM..GENERATOR_Y_RANGE_TOP,
     )
 
+    private val customStepGenerator = RandomEntriesGenerator(
+        xRange = IntProgression.fromClosedRange(rangeStart = 0, rangeEnd = 24, step = 2),
+        yRange = GENERATOR_Y_RANGE_BOTTOM..GENERATOR_Y_RANGE_TOP,
+    )
+
     internal val chartEntryModelProducer: ChartEntryModelProducer = ChartEntryModelProducer()
+
+    internal val chartStepEntryModelProducer: ChartEntryModelProducer = ChartEntryModelProducer()
 
     internal val multiChartEntryModelProducer: ChartEntryModelProducer = ChartEntryModelProducer()
 
@@ -56,6 +63,7 @@ internal class ShowcaseViewModel : ViewModel() {
                         multiGenerator.generateRandomEntries()
                     },
                 )
+                chartStepEntryModelProducer.setEntries(customStepGenerator.generateRandomEntries())
                 delay(UPDATE_FREQUENCY)
             }
         }

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/util/RandomEntriesGenerator.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/util/RandomEntriesGenerator.kt
@@ -31,8 +31,8 @@ import kotlin.random.Random
  * @param yRange the range from which y values are randomly selected.
  */
 public class RandomEntriesGenerator(
-    private val xRange: IntRange = 0..X_RANGE_TOP,
-    private val yRange: IntRange = 0..Y_RANGE_TOP,
+    private val xRange: IntProgression = 0..X_RANGE_TOP,
+    private val yRange: IntProgression = 0..Y_RANGE_TOP,
 ) {
     /**
      * Generates a [List] of [FloatEntry] instances with randomized y values.


### PR DESCRIPTION
Use IntProgression for RandomEntriesGenerator by default to be able to use sequences like `0, 2, 4, 6...`
<img width="514" alt="Снимок экрана 2022-07-02 в 19 32 43" src="https://user-images.githubusercontent.com/22121595/177008902-27c2fdd6-c10d-459f-8e12-e17a829fffa7.png">

