### PR TITLE
Replace `TickType` with customizable `TickPosition`

### DIFF
--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/chart/ColumnChart.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/chart/ColumnChart.kt
@@ -33,6 +33,7 @@ import com.patrykandpatryk.vico.compose.component.shape.textComponent
 import com.patrykandpatryk.vico.compose.dimensions.dimensionsOf
 import com.patrykandpatryk.vico.core.DefaultDimens
 import com.patrykandpatryk.vico.core.axis.formatter.PercentageFormatAxisValueFormatter
+import com.patrykandpatryk.vico.core.axis.horizontal.HorizontalAxis
 import com.patrykandpatryk.vico.core.axis.vertical.VerticalAxis
 import com.patrykandpatryk.vico.core.chart.decoration.ThresholdLine
 import com.patrykandpatryk.vico.core.component.shape.ShapeComponent
@@ -66,7 +67,12 @@ internal fun ComposeColumnChart(
         chart = columnChart,
         chartModelProducer = chartEntryModelProducer,
         startAxis = startAxis,
-        bottomAxis = bottomAxis(),
+        bottomAxis = bottomAxis(
+            tickPosition = HorizontalAxis.TickPosition.Center(
+                offset = 1,
+                spacing = 3,
+            ),
+        ),
         marker = marker(),
     )
 }

--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/preview/TickPositionPreviews.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/preview/TickPositionPreviews.kt
@@ -1,0 +1,121 @@
+@file:Suppress("Deprecation")
+/*
+ * Copyright 2022 Patryk Goworowski and Patryk Michalik
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatryk.vico.sample.preview
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.patrykandpatryk.vico.compose.axis.horizontal.bottomAxis
+import com.patrykandpatryk.vico.compose.axis.vertical.startAxis
+import com.patrykandpatryk.vico.compose.chart.Chart
+import com.patrykandpatryk.vico.compose.chart.column.columnChart
+import com.patrykandpatryk.vico.core.axis.AxisPosition
+import com.patrykandpatryk.vico.core.axis.formatter.AxisValueFormatter
+import com.patrykandpatryk.vico.core.axis.horizontal.HorizontalAxis
+import com.patrykandpatryk.vico.core.chart.Chart
+import com.patrykandpatryk.vico.core.entry.ChartEntryModel
+import com.patrykandpatryk.vico.core.entry.entryModelOf
+
+private const val WHITE: Long = 0xFFFFFFFF
+
+private val model = entryModelOf(1, 2, 3, 4, 3)
+
+private val chart: Chart<ChartEntryModel>
+    @Composable get() = columnChart(maxX = 6f)
+
+private val axisValueFormatter = AxisValueFormatter<AxisPosition.Horizontal.Bottom> { i, _ ->
+    "${i.toInt()} Lorem ipsum"
+}
+
+@Preview(widthDp = 400, backgroundColor = WHITE, showBackground = true)
+@Composable
+public fun ColumnChartEdgeTickPosition() {
+    Chart(
+        chart = chart,
+        model = model,
+        startAxis = startAxis(),
+        bottomAxis = bottomAxis(
+            tickPosition = HorizontalAxis.TickPosition.Edge,
+            valueFormatter = axisValueFormatter,
+        ),
+        isHorizontalScrollEnabled = false,
+    )
+}
+
+@Preview(widthDp = 400, backgroundColor = WHITE, showBackground = true)
+@Composable
+public fun ColumnChartWithCustomEdgeTickPosition() {
+    Chart(
+        chart = chart,
+        model = model,
+        startAxis = startAxis(),
+        bottomAxis = bottomAxis(
+            tickPosition = HorizontalAxis.TickPosition.Center(offset = 0, spacing = 2),
+            valueFormatter = axisValueFormatter,
+        ),
+        isHorizontalScrollEnabled = false,
+    )
+}
+
+@Preview(widthDp = 400, backgroundColor = WHITE, showBackground = true)
+@Composable
+public fun ColumnChartWithEdgeTickPosition() {
+    Chart(
+        chart = chart,
+        model = model,
+        startAxis = startAxis(),
+        bottomAxis = bottomAxis(
+            tickPosition = HorizontalAxis.TickPosition.Center(),
+            valueFormatter = axisValueFormatter,
+        ),
+        isHorizontalScrollEnabled = false,
+    )
+}
+
+@Preview(widthDp = 400, backgroundColor = WHITE, showBackground = true)
+@Composable
+public fun ColumnChartWithEdgeTickPositionDeprecated() {
+    Chart(
+        chart = chart,
+        model = model,
+        startAxis = startAxis(),
+        bottomAxis = bottomAxis(
+            valueFormatter = axisValueFormatter,
+        ).apply {
+            tickType = HorizontalAxis.TickType.Minor
+        },
+        isHorizontalScrollEnabled = false,
+    )
+}
+
+@Preview(widthDp = 400, backgroundColor = WHITE, showBackground = true)
+@Composable
+public fun ColumnChartWithCenterTickPositionDeprecated() {
+    Chart(
+        modifier = Modifier,
+        chart = chart,
+        model = model,
+        startAxis = startAxis(),
+        bottomAxis = bottomAxis(
+            valueFormatter = axisValueFormatter,
+        ).apply {
+            tickType = HorizontalAxis.TickType.Major
+        },
+        isHorizontalScrollEnabled = false,
+    )
+}

--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.patrykandpatryk.vico.sample.util.SampleChart
 import com.patrykandpatryk.vico.sample.util.Tab
@@ -53,18 +54,20 @@ internal fun ChartPager(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 32.dp),
+                        .padding(vertical = 32.dp, horizontal = 16.dp),
                 ) {
                     Text(
                         text = stringResource(id = sampleCharts[targetState].labelResourceId),
                         style = MaterialTheme.typography.headlineSmall,
                         color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center,
                     )
                     Text(
                         text = stringResource(id = sampleCharts[targetState].descriptionResourceId),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(top = 4.dp),
+                        textAlign = TextAlign.Center,
                     )
                 }
             }

--- a/sample/src/main/res/layout/column_chart.xml
+++ b/sample/src/main/res/layout/column_chart.xml
@@ -28,6 +28,7 @@
         app:chart="column"
         app:showBottomAxis="true"
         app:showStartAxis="true"
+        app:axisStyle="@style/ColumnChartAxisStyle"
         app:columnChartStyle="@style/ColumnChartColumnChartStyle" />
 
 </FrameLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="line_chart_label">Line chart</string>
     <string name="line_chart_description">Persistent marker &amp; customized guidelines</string>
     <string name="column_chart_label">Column chart</string>
-    <string name="column_chart_description">Percentages &amp; threshold line</string>
+    <string name="column_chart_description">Percentages, threshold line &amp; custom tick position</string>
     <string name="composed_chart_label">Composed chart</string>
     <string name="composed_chart_description">Axes at top and end</string>
     <string name="stacked_column_chart_label">Stacked column chart</string>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -61,6 +61,12 @@
         <item name="color">#3D84A8</item>
     </style>
 
+    <style name="ColumnChartAxisStyle">
+        <item name="horizontalAxisTickPosition">center</item>
+        <item name="horizontalAxisTickOffset">1</item>
+        <item name="horizontalAxisTickSpacing">3</item>
+    </style>
+
     <style name="StackedColumnChartAxisStyle">
         <item name="labelRotationDegrees">45</item>
     </style>

--- a/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/axis/horizontal/HorizontalAxis.kt
+++ b/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/axis/horizontal/HorizontalAxis.kt
@@ -39,7 +39,7 @@ import com.patrykandpatryk.vico.core.component.text.TextComponent
  * @param axis the [LineComponent] to use for the axis line.
  * @param tick the [LineComponent] to use for ticks.
  * @param tickLength the length of ticks.
- * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows using custom offset
+ * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using a custom offset
  * and spacing for both ticks and labels.
  * @param guideline the [LineComponent] to use for guidelines.
  * @param valueFormatter the [AxisValueFormatter] for the axis.
@@ -82,7 +82,7 @@ public fun topAxis(
  * @param axis the [LineComponent] to use for the axis line.
  * @param tick the [LineComponent] to use for ticks.
  * @param tickLength the length of ticks.
- * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows using custom offset
+ * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using a custom offset
  * and spacing for both ticks and labels.
  * @param guideline the [LineComponent] to use for guidelines.
  * @param valueFormatter the [AxisValueFormatter] for the axis.

--- a/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/axis/horizontal/HorizontalAxis.kt
+++ b/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/axis/horizontal/HorizontalAxis.kt
@@ -39,8 +39,8 @@ import com.patrykandpatryk.vico.core.component.text.TextComponent
  * @param axis the [LineComponent] to use for the axis line.
  * @param tick the [LineComponent] to use for ticks.
  * @param tickLength the length of ticks.
- * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using a custom offset
- * and spacing for both ticks and labels.
+ * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using a custom
+ * offset and spacing for both ticks and labels.
  * @param guideline the [LineComponent] to use for guidelines.
  * @param valueFormatter the [AxisValueFormatter] for the axis.
  * @param sizeConstraint the [Axis.SizeConstraint] for the axis. This determines its height.
@@ -82,8 +82,8 @@ public fun topAxis(
  * @param axis the [LineComponent] to use for the axis line.
  * @param tick the [LineComponent] to use for ticks.
  * @param tickLength the length of ticks.
- * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using a custom offset
- * and spacing for both ticks and labels.
+ * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using a custom
+ * offset and spacing for both ticks and labels.
  * @param guideline the [LineComponent] to use for guidelines.
  * @param valueFormatter the [AxisValueFormatter] for the axis.
  * @param sizeConstraint the [Axis.SizeConstraint] for the axis. This determines its height.

--- a/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/axis/horizontal/HorizontalAxis.kt
+++ b/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/axis/horizontal/HorizontalAxis.kt
@@ -39,6 +39,8 @@ import com.patrykandpatryk.vico.core.component.text.TextComponent
  * @param axis the [LineComponent] to use for the axis line.
  * @param tick the [LineComponent] to use for ticks.
  * @param tickLength the length of ticks.
+ * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows using custom offset
+ * and spacing for both ticks and labels.
  * @param guideline the [LineComponent] to use for guidelines.
  * @param valueFormatter the [AxisValueFormatter] for the axis.
  * @param sizeConstraint the [Axis.SizeConstraint] for the axis. This determines its height.
@@ -52,6 +54,7 @@ public fun topAxis(
     axis: LineComponent? = axisLineComponent(),
     tick: LineComponent? = axisTickComponent(),
     tickLength: Dp = currentChartStyle.axis.axisTickLength,
+    tickPosition: HorizontalAxis.TickPosition = HorizontalAxis.TickPosition.Edge,
     guideline: LineComponent? = axisGuidelineComponent(),
     valueFormatter: AxisValueFormatter<AxisPosition.Horizontal.Top> = DecimalFormatAxisValueFormatter(),
     sizeConstraint: Axis.SizeConstraint = Axis.SizeConstraint.Auto(),
@@ -65,6 +68,7 @@ public fun topAxis(
     this.guideline = guideline
     this.valueFormatter = valueFormatter
     this.tickLengthDp = tickLength.value
+    this.tickPosition = tickPosition
     this.sizeConstraint = sizeConstraint
     this.labelRotationDegrees = labelRotationDegrees
     this.titleComponent = titleComponent
@@ -78,6 +82,8 @@ public fun topAxis(
  * @param axis the [LineComponent] to use for the axis line.
  * @param tick the [LineComponent] to use for ticks.
  * @param tickLength the length of ticks.
+ * @param tickPosition defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows using custom offset
+ * and spacing for both ticks and labels.
  * @param guideline the [LineComponent] to use for guidelines.
  * @param valueFormatter the [AxisValueFormatter] for the axis.
  * @param sizeConstraint the [Axis.SizeConstraint] for the axis. This determines its height.
@@ -91,6 +97,7 @@ public fun bottomAxis(
     axis: LineComponent? = axisLineComponent(),
     tick: LineComponent? = axisTickComponent(),
     tickLength: Dp = currentChartStyle.axis.axisTickLength,
+    tickPosition: HorizontalAxis.TickPosition = HorizontalAxis.TickPosition.Edge,
     guideline: LineComponent? = axisGuidelineComponent(),
     valueFormatter: AxisValueFormatter<AxisPosition.Horizontal.Bottom> = DecimalFormatAxisValueFormatter(),
     sizeConstraint: Axis.SizeConstraint = Axis.SizeConstraint.Auto(),
@@ -104,6 +111,7 @@ public fun bottomAxis(
     this.guideline = guideline
     this.valueFormatter = valueFormatter
     this.tickLengthDp = tickLength.value
+    this.tickPosition = tickPosition
     this.sizeConstraint = sizeConstraint
     this.labelRotationDegrees = labelRotationDegrees
     this.titleComponent = titleComponent

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
@@ -52,7 +52,7 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
     /**
      * Defines the tick placement.
      */
-    @Deprecated(message = "Tick type is now defined by `tickPosition`.", replaceWith = ReplaceWith("tickPosition"))
+    @Deprecated(message = "The tick type is now defined by `tickPosition`.", replaceWith = ReplaceWith("tickPosition"))
     public var tickType: TickType? = null
         set(value) {
             field = value
@@ -294,7 +294,7 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
     }
 
     /**
-     * [TickPosition] defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using custom offset
+     * [TickPosition] defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using a custom offset
      * and spacing for both ticks and labels.
      *
      * @param offset the index at which ticks and labels start to be drawn. The default is 0.
@@ -307,12 +307,12 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
     ) {
 
         /**
-         * Returns a tick count required by given [TickPosition].
+         * Returns the tick count required by given [TickPosition].
          */
         public abstract fun getTickCount(entryLength: Int): Int
 
         /**
-         * Returns a chart bounds inset required by given [TickPosition].
+         * Returns the chart bounds inset required by the given [TickPosition].
          */
         public abstract fun getTickInset(tickThickness: Float): Float
 
@@ -376,7 +376,7 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
         public companion object {
 
             /**
-             * Returns a [TickPosition] that replaces deprecated [type].
+             * Returns the [TickPosition] that replaces the deprecated [type].
              */
             public fun fromTickType(type: TickType): TickPosition = when (type) {
                 TickType.Minor -> Edge
@@ -395,7 +395,7 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
         /**
          * Defines the tick placement.
          */
-        @Deprecated(message = "Tick type is now defined by `tickPosition`.", replaceWith = ReplaceWith("tickPosition"))
+        @Deprecated(message = "The tick type is now defined by `tickPosition`.", replaceWith = ReplaceWith("tickPosition"))
         public var tickType: TickType? = null
 
         /**

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
@@ -364,13 +364,8 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
             public constructor(spacing: Int) : this(offset = spacing, spacing = spacing)
 
             init {
-                if (offset < 0) {
-                    throw IllegalArgumentException("The offset cannot be negative. Received $offset.")
-                }
-
-                if (spacing < 1) {
-                    throw IllegalArgumentException("The offset cannot be less than 1. Received $spacing.")
-                }
+                require(offset >= 0) { "The offset cannot be negative. Received $offset." }
+                require(spacing >= 1) { "The offset cannot be less than 1. Received $spacing." }
             }
 
             override fun getTickCount(entryLength: Int): Int = entryLength

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
@@ -294,8 +294,8 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
     }
 
     /**
-     * [TickPosition] defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using a custom offset
-     * and spacing for both ticks and labels.
+     * [TickPosition] defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using a custom
+     * offset and spacing for both ticks and labels.
      *
      * @param offset the index at which ticks and labels start to be drawn. The default is 0.
      * @param spacing defines how often ticks should be drawn, where 1 means a tick is drawn for each entry,
@@ -395,7 +395,10 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
         /**
          * Defines the tick placement.
          */
-        @Deprecated(message = "The tick type is now defined by `tickPosition`.", replaceWith = ReplaceWith("tickPosition"))
+        @Deprecated(
+            message = "The tick type is now defined by `tickPosition`.",
+            replaceWith = ReplaceWith("tickPosition"),
+        )
         public var tickType: TickType? = null
 
         /**

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
@@ -111,11 +111,11 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
                 )
 
             tick
-                ?.takeIf { shouldDraw }
+                .takeIf { shouldDraw }
                 ?.drawVertical(context = context, top = tickMarkTop, bottom = tickMarkBottom, centerX = tickCenter)
 
             label
-                ?.takeIf { index < entryLength && shouldDraw }
+                .takeIf { index < entryLength && shouldDraw }
                 ?.drawText(
                     context = context,
                     text = valueFormatter.formatValue(valueIndex, chartValues),

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
@@ -294,7 +294,7 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
     }
 
     /**
-     * [TickPosition] defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows using custom offset
+     * [TickPosition] defines the position of ticks. [HorizontalAxis.TickPosition.Center] allows for using custom offset
      * and spacing for both ticks and labels.
      *
      * @param offset the index at which ticks and labels start to be drawn. The default is 0.

--- a/vico/view/src/main/java/com/patrykandpatryk/vico/view/theme/ThemeHandler.kt
+++ b/vico/view/src/main/java/com/patrykandpatryk/vico/view/theme/ThemeHandler.kt
@@ -172,6 +172,14 @@ internal class ThemeHandler(
                         val values = VerticalAxis.VerticalLabelPosition.values()
                         values[value % values.size]
                     }
+            } else if (this is HorizontalAxis.Builder<*>) {
+                tickPosition = when (axisStyle.getInteger(R.styleable.Axis_horizontalAxisTickPosition, 0)) {
+                    0 -> HorizontalAxis.TickPosition.Edge
+                    else -> HorizontalAxis.TickPosition.Center(
+                        offset = axisStyle.getInteger(R.styleable.Axis_horizontalAxisTickOffset, 0),
+                        spacing = axisStyle.getInteger(R.styleable.Axis_horizontalAxisTickSpacing, 1),
+                    )
+                }
             }
         }.also { axisStyle.recycle() }
     }

--- a/vico/view/src/main/res/values/attrs.xml
+++ b/vico/view/src/main/res/values/attrs.xml
@@ -78,6 +78,12 @@
         <attr name="titleStyle" format="reference" />
         <attr name="title" format="string|reference" />
         <attr name="showTitle" format="boolean|reference" />
+        <attr name="horizontalAxisTickPosition" format="enum">
+            <enum name="edge" value="0" />
+            <enum name="center" value="1" />
+        </attr>
+        <attr name="horizontalAxisTickOffset" format="integer"/>
+        <attr name="horizontalAxisTickSpacing" format="integer"/>
     </declare-styleable>
 
     <declare-styleable name="LineComponent">


### PR DESCRIPTION
This PR solves  #106.

There are two `TickPosition`s:
1. `Edge`, which replaces `TickType.Minor`. It works exactly the same as before.
2. `Center`, which replaces `TickType.Major`. Now it may have custom `offset` and `spacing`.

The column chart in the sample app now uses `TickPosition.Center` with `offset` equal to `1` and `spacing` equal to `3`.


<img src="https://user-images.githubusercontent.com/14221573/180658741-f691dff3-6e4c-4485-af7e-9d9823d948d7.png" width="320"/>
 