### PR TITLE
Crash #115 marker

### DIFF
--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/column/ColumnChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/column/ColumnChart.kt
@@ -259,12 +259,14 @@ public open class ColumnChart(
         columnCenterX: Float,
         column: LineComponent,
     ) {
-        entryLocationMap.put(
-            x = columnCenterX,
-            y = columnTop.coerceIn(bounds.top, bounds.bottom),
-            entry = entry,
-            color = column.color,
-        )
+        if (columnCenterX in bounds.left..bounds.right) {
+            entryLocationMap.put(
+                x = columnCenterX,
+                y = columnTop.coerceIn(bounds.top, bounds.bottom),
+                entry = entry,
+                color = column.color,
+            )
+        }
     }
 
     override fun updateChartValues(chartValuesManager: ChartValuesManager, model: ChartEntryModel) {

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/component/shape/cornered/CorneredShape.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/component/shape/cornered/CorneredShape.kt
@@ -39,6 +39,9 @@ public open class CorneredShape(
     public val bottomLeft: Corner = Corner.Sharp,
 ) : Shape {
 
+    private val Float.nonZero: Float
+        get() = if (this == 0f) 1f else this
+
     /**
      * Returns a scale factor for the corner size, which will prevent graphical glitches in case the size of the
      * corners is larger than the shape’s dimensions.
@@ -54,10 +57,10 @@ public open class CorneredShape(
         val bR = bottomRight.getCornerSize(availableSize, density)
         val bL = bottomLeft.getCornerSize(availableSize, density)
         return minOf(
-            width / (tL + tR),
-            width / (bL + bR),
-            height / (tL + bL),
-            height / (tR + bR),
+            width / (tL + tR).nonZero,
+            width / (bL + bR).nonZero,
+            height / (tL + bL).nonZero,
+            height / (tR + bR).nonZero,
         )
     }
 

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/component/shape/cornered/MarkerCorneredShape.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/component/shape/cornered/MarkerCorneredShape.kt
@@ -82,7 +82,7 @@ public open class MarkerCorneredShape(
             val cornerScale = getCornerScale(right - left, bottom - top, density)
 
             val minLeft = left + bottomLeft.getCornerSize(availableCornerSize, density) * cornerScale
-            val maxLeft = right - (bottomRight.getCornerSize(availableCornerSize, density) * cornerScale)
+            val maxLeft = right - bottomRight.getCornerSize(availableCornerSize, density) * cornerScale
 
             val coercedTickSize = tickSize.coerceAtMost((maxLeft - minLeft).half.coerceAtLeast(0f))
 

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/component/shape/cornered/MarkerCorneredShape.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/component/shape/cornered/MarkerCorneredShape.kt
@@ -21,6 +21,7 @@ import android.graphics.Path
 import com.patrykandpatryk.vico.core.DEF_MARKER_TICK_SIZE
 import com.patrykandpatryk.vico.core.component.shape.Shape
 import com.patrykandpatryk.vico.core.context.DrawContext
+import com.patrykandpatryk.vico.core.extension.half
 
 /**
  * [MarkerCorneredShape] is an extension of [CorneredShape] that supports drawing a triangular tick at a given point.
@@ -81,12 +82,19 @@ public open class MarkerCorneredShape(
             val cornerScale = getCornerScale(right - left, bottom - top, density)
 
             val minLeft = left + bottomLeft.getCornerSize(availableCornerSize, density) * cornerScale
-            val maxLeft = right - (bottomRight.getCornerSize(availableCornerSize, density) * cornerScale + tickSize * 2)
+            val maxLeft = right - (bottomRight.getCornerSize(availableCornerSize, density) * cornerScale)
 
-            val tickTopLeft = (tickX - tickSize).coerceIn(minLeft, maxLeft)
-            path.moveTo(tickTopLeft, bottom)
-            path.lineTo(tickX, bottom + tickSize)
-            path.lineTo(tickTopLeft + tickSize * 2, bottom)
+            val coercedTickSize = tickSize.coerceAtMost((maxLeft - minLeft).half.coerceAtLeast(0f))
+
+            (tickX - coercedTickSize)
+                .takeIf { minLeft < maxLeft }
+                ?.coerceIn(minLeft, maxLeft)
+                ?.also { tickTopLeft ->
+                    path.moveTo(tickTopLeft, bottom)
+                    path.lineTo(tickX, bottom + tickSize)
+                    path.lineTo(tickTopLeft + coercedTickSize * 2, bottom)
+                }
+
             path.close()
             context.canvas.drawPath(path, paint)
         } else {


### PR DESCRIPTION
This PR fixes #115, incorrect calculation of corner scale for sharp corners, and marker indication in `ColumnChart` going out of bounds.