### PR TITLE
Point position improvements

### DIFF
--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -55,6 +55,7 @@
 
     <style name="ComposedChartLineChartStyle">
         <item name="line1Spec">@style/ComposedChartLine1Spec</item>
+        <item name="pointPosition">start</item>
     </style>
 
     <style name="ComposedChartLine1Spec">

--- a/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/axis/horizontal/HorizontalAxis.kt
+++ b/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/axis/horizontal/HorizontalAxis.kt
@@ -47,7 +47,6 @@ import com.patrykandpatryk.vico.core.component.text.TextComponent
  * @param labelRotationDegrees the rotation of axis labels in degrees.
  * @param titleComponent an optional [TextComponent] use as the axis title.
  * @param title the axis title.
- * @param labelPosition defines the position of labels.
  */
 @Composable
 public fun topAxis(
@@ -62,7 +61,6 @@ public fun topAxis(
     labelRotationDegrees: Float = currentChartStyle.axis.axisLabelRotationDegrees,
     titleComponent: TextComponent? = null,
     title: CharSequence? = null,
-    labelPosition: HorizontalAxis.LabelPosition = HorizontalAxis.LabelPosition.Center,
 ): HorizontalAxis<AxisPosition.Horizontal.Top> = createHorizontalAxis {
     this.label = label
     this.axis = axis
@@ -75,7 +73,6 @@ public fun topAxis(
     this.labelRotationDegrees = labelRotationDegrees
     this.titleComponent = titleComponent
     this.title = title
-    this.labelPosition = labelPosition
 }
 
 /**
@@ -93,7 +90,6 @@ public fun topAxis(
  * @param labelRotationDegrees the rotation of axis labels in degrees.
  * @param titleComponent an optional [TextComponent] use as the axis title.
  * @param title the axis title.
- * @param labelPosition defines the position of labels.
  */
 @Composable
 public fun bottomAxis(
@@ -108,7 +104,6 @@ public fun bottomAxis(
     titleComponent: TextComponent? = null,
     title: CharSequence? = null,
     labelRotationDegrees: Float = currentChartStyle.axis.axisLabelRotationDegrees,
-    labelPosition: HorizontalAxis.LabelPosition = HorizontalAxis.LabelPosition.Center,
 ): HorizontalAxis<AxisPosition.Horizontal.Bottom> = createHorizontalAxis {
     this.label = label
     this.axis = axis
@@ -121,5 +116,4 @@ public fun bottomAxis(
     this.labelRotationDegrees = labelRotationDegrees
     this.titleComponent = titleComponent
     this.title = title
-    this.labelPosition = labelPosition
 }

--- a/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/chart/line/LineChart.kt
+++ b/vico/compose/src/main/java/com/patrykandpatryk/vico/compose/chart/line/LineChart.kt
@@ -60,6 +60,7 @@ import com.patrykandpatryk.vico.core.marker.Marker
  * @param targetVerticalAxisPosition if this is set, any [com.patrykandpatryk.vico.core.axis.AxisRenderer] with an
  * [AxisPosition] equal to the provided value will use the [ChartValues] provided by this chart.
  * This is meant to be used with [com.patrykandpatryk.vico.core.chart.composed.ComposedChart].
+ * @param pointPosition the horizontal position of each point in its corresponding segment.
  *
  * @see com.patrykandpatryk.vico.compose.chart.Chart
  * @see ColumnChart
@@ -75,6 +76,7 @@ public fun lineChart(
     decorations: List<Decoration>? = null,
     persistentMarkers: Map<Float, Marker>? = null,
     targetVerticalAxisPosition: AxisPosition.Vertical? = null,
+    pointPosition: LineChart.PointPosition = LineChart.PointPosition.Center,
 ): LineChart = remember { LineChart() }.apply {
     this.lines = lines
     this.spacingDp = spacing.value
@@ -83,6 +85,7 @@ public fun lineChart(
     this.minY = minY
     this.maxY = maxY
     this.targetVerticalAxisPosition = targetVerticalAxisPosition
+    this.pointPosition = pointPosition
     decorations?.also(::setDecorations)
     persistentMarkers?.also(::setPersistentMarkers)
 }
@@ -100,7 +103,6 @@ public fun lineChart(
  * @param dataLabelVerticalPosition the vertical position of data labels relative to the line.
  * @param dataLabelValueFormatter the [ValueFormatter] to use for data labels.
  * @param dataLabelRotationDegrees the rotation of data labels in degrees.
- * @param pointPosition the horizontal position of each point in its corresponding segment.
  * @param pointConnector the [LineSpec.PointConnector] for the line.
  *
  * @see LineChart
@@ -124,7 +126,6 @@ public fun lineSpec(
     dataLabelVerticalPosition: VerticalPosition = VerticalPosition.Top,
     dataLabelValueFormatter: ValueFormatter = DecimalFormatValueFormatter(),
     dataLabelRotationDegrees: Float = 0f,
-    pointPosition: LineSpec.PointPosition = LineSpec.PointPosition.Center,
     pointConnector: LineSpec.PointConnector = DefaultPointConnector(),
 ): LineSpec = LineSpec(
     lineColor = lineColor.toArgb(),
@@ -137,7 +138,6 @@ public fun lineSpec(
     dataLabelVerticalPosition = dataLabelVerticalPosition,
     dataLabelValueFormatter = dataLabelValueFormatter,
     dataLabelRotationDegrees = dataLabelRotationDegrees,
-    pointPosition = pointPosition,
     pointConnector = pointConnector,
 )
 
@@ -155,7 +155,6 @@ public fun lineSpec(
  * @param dataLabelVerticalPosition the vertical position of data labels relative to the line.
  * @param dataLabelValueFormatter the [ValueFormatter] to use for data labels.
  * @param dataLabelRotationDegrees the rotation of data labels in degrees.
- * @param pointPosition the horizontal position of each point in its corresponding segment.
  *
  * @see LineChart
  * @see LineChart.LineSpec
@@ -201,7 +200,6 @@ public fun lineSpec(
     dataLabelVerticalPosition: VerticalPosition = VerticalPosition.Top,
     dataLabelValueFormatter: ValueFormatter = DecimalFormatValueFormatter(),
     dataLabelRotationDegrees: Float = 0f,
-    pointPosition: LineSpec.PointPosition = LineSpec.PointPosition.Center,
 ): LineSpec = LineSpec(
     lineColor = lineColor.toArgb(),
     lineThicknessDp = lineThickness.value,
@@ -213,7 +211,6 @@ public fun lineSpec(
     dataLabelVerticalPosition = dataLabelVerticalPosition,
     dataLabelValueFormatter = dataLabelValueFormatter,
     dataLabelRotationDegrees = dataLabelRotationDegrees,
-    pointPosition = pointPosition,
     pointConnector = DefaultPointConnector(cubicStrength = cubicStrength),
 )
 

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/axis/horizontal/HorizontalAxis.kt
@@ -64,11 +64,6 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
      */
     public var tickPosition: TickPosition = TickPosition.Edge
 
-    /**
-     * Defines the position of labels.
-     */
-    public var labelPosition: LabelPosition = LabelPosition.Center
-
     override fun drawBehindChart(context: ChartDrawContext): Unit = with(context) {
         val clipRestoreCount = canvas.save()
         val tickMarkTop = if (position.isBottom) bounds.top else bounds.bottom - tickLength
@@ -88,7 +83,7 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
         val scrollAdjustment = (abs(x = horizontalScroll) / tickDrawStep).toInt()
         val textY = if (position.isBottom) tickMarkBottom else tickMarkTop
 
-        val labelPositionOffset = when (labelPosition) {
+        val labelPositionOffset = when (segmentProperties.labelPositionOrDefault) {
             LabelPosition.Start -> 0f
             LabelPosition.Center -> tickDrawStep.half
         }
@@ -102,6 +97,7 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
             startValueIndex = chartValues.minX + scrollAdjustment * step,
             step = step,
             entryLength = entryLength,
+            labelsToSkip = segmentProperties.labelPositionOrDefault.labelsToSkip,
         ) { index, valueIndex, shouldDraw ->
 
             guideline
@@ -176,6 +172,7 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
         startValueIndex: Float,
         step: Float,
         entryLength: Int,
+        labelsToSkip: Int,
         action: (index: Int, valueIndex: Float, shouldDraw: Boolean) -> Unit,
     ) {
         var valueIndex = startValueIndex
@@ -183,7 +180,7 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
         for (index in 0 until tickPosition.getTickCount(entryLength)) {
             val shouldDraw = valueIndex >= tickPosition.offset &&
                 (valueIndex - tickPosition.offset) % tickPosition.spacing == 0f &&
-                (index >= labelPosition.labelsToSkip || tickPosition.offset > 0)
+                (index >= labelsToSkip || tickPosition.offset > 0)
 
             action(
                 index,
@@ -446,11 +443,6 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
         public var tickPosition: TickPosition = TickPosition.Edge
 
         /**
-         * Defines the position of labels.
-         */
-        public var labelPosition: LabelPosition = LabelPosition.Center
-
-        /**
          * Creates an instance of [HorizontalAxis] using the properties set in this [Builder].
          */
         @Suppress("UNCHECKED_CAST")
@@ -463,7 +455,6 @@ public class HorizontalAxis<Position : AxisPosition.Horizontal>(
             return setTo(HorizontalAxis(position = position)).also { axis ->
                 tickType?.also { axis.tickType = it }
                 axis.tickPosition = tickPosition
-                axis.labelPosition = labelPosition
             } as HorizontalAxis<T>
         }
     }

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/LineSpecExtensions.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/LineSpecExtensions.kt
@@ -31,7 +31,6 @@ public fun LineChart.LineSpec.copy(
     lineCap: Paint.Cap = this.lineCap,
     point: Component? = this.point,
     pointSizeDp: Float = this.pointSizeDp,
-    pointPosition: LineChart.LineSpec.PointPosition = this.pointPosition,
     pointConnector: LineChart.LineSpec.PointConnector = this.pointConnector,
 ): LineChart.LineSpec = LineChart.LineSpec(
     lineColor = lineColor,
@@ -40,6 +39,5 @@ public fun LineChart.LineSpec.copy(
     lineCap = lineCap,
     point = point,
     pointSizeDp = pointSizeDp,
-    pointPosition = pointPosition,
     pointConnector = pointConnector,
 )

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/composed/ComposedChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/composed/ComposedChart.kt
@@ -16,6 +16,7 @@
 
 package com.patrykandpatryk.vico.core.chart.composed
 
+import com.patrykandpatryk.vico.core.axis.horizontal.HorizontalAxis
 import com.patrykandpatryk.vico.core.chart.BaseChart
 import com.patrykandpatryk.vico.core.chart.Chart
 import com.patrykandpatryk.vico.core.chart.draw.ChartDrawContext
@@ -98,10 +99,21 @@ public class ComposedChart<Model : ChartEntryModel>(
             segmentProperties.apply {
                 cellWidth = maxOf(cellWidth, chartSegmentProperties.cellWidth)
                 marginWidth = maxOf(marginWidth, chartSegmentProperties.marginWidth)
+                labelPosition = getProperLabelPosition(labelPosition, chartSegmentProperties.labelPosition)
             }
         }
         return segmentProperties
     }
+
+    private fun getProperLabelPosition(
+        first: HorizontalAxis.LabelPosition?,
+        second: HorizontalAxis.LabelPosition?,
+    ): HorizontalAxis.LabelPosition =
+        if (first == null || first == second && second == HorizontalAxis.LabelPosition.Start) {
+            HorizontalAxis.LabelPosition.Start
+        } else {
+            HorizontalAxis.LabelPosition.Center
+        }
 
     override fun updateChartValues(
         chartValuesManager: ChartValuesManager,

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/line/LineChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/line/LineChart.kt
@@ -23,6 +23,7 @@ import android.graphics.RectF
 import com.patrykandpatryk.vico.core.DefaultDimens
 import com.patrykandpatryk.vico.core.annotation.LongParameterListDrawFunction
 import com.patrykandpatryk.vico.core.axis.AxisPosition
+import com.patrykandpatryk.vico.core.axis.horizontal.HorizontalAxis
 import com.patrykandpatryk.vico.core.chart.BaseChart
 import com.patrykandpatryk.vico.core.chart.DefaultPointConnector
 import com.patrykandpatryk.vico.core.chart.draw.ChartDrawContext
@@ -38,7 +39,6 @@ import com.patrykandpatryk.vico.core.chart.values.ChartValues
 import com.patrykandpatryk.vico.core.chart.values.ChartValuesManager
 import com.patrykandpatryk.vico.core.component.Component
 import com.patrykandpatryk.vico.core.component.shape.shader.DynamicShader
-import com.patrykandpatryk.vico.core.component.text.HorizontalPosition
 import com.patrykandpatryk.vico.core.component.text.TextComponent
 import com.patrykandpatryk.vico.core.component.text.VerticalPosition
 import com.patrykandpatryk.vico.core.component.text.inBounds
@@ -280,7 +280,7 @@ public open class LineChart(
     ): Unit = with(context) {
         resetTempData()
 
-        val (cellWidth, spacing, _) = segmentProperties
+        val (cellWidth, spacing) = segmentProperties
 
         model.entries.forEachIndexed { index, entries ->
 
@@ -484,6 +484,7 @@ public open class LineChart(
         segmentProperties.set(
             cellWidth = lines.maxOf { it.pointSizeDp.pixels },
             marginWidth = spacingDp.pixels,
+            labelPosition = pointPosition.labelPosition,
         )
     }
 
@@ -517,8 +518,8 @@ public open class LineChart(
     /**
      * Defines the horizontal position of each point in its corresponding segment.
      */
-    public enum class PointPosition(internal val position: HorizontalPosition) {
-        Start(position = HorizontalPosition.Start),
-        Center(position = HorizontalPosition.Center),
+    public enum class PointPosition(internal val labelPosition: HorizontalAxis.LabelPosition) {
+        Start(labelPosition = HorizontalAxis.LabelPosition.Start),
+        Center(labelPosition = HorizontalAxis.LabelPosition.Center),
     }
 }

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/line/LineChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/line/LineChart.kt
@@ -30,6 +30,7 @@ import com.patrykandpatryk.vico.core.chart.draw.segmentWidth
 import com.patrykandpatryk.vico.core.chart.forEachIn
 import com.patrykandpatryk.vico.core.chart.insets.Insets
 import com.patrykandpatryk.vico.core.chart.line.LineChart.LineSpec
+import com.patrykandpatryk.vico.core.chart.line.LineChart.LineSpec.PointConnector
 import com.patrykandpatryk.vico.core.chart.put
 import com.patrykandpatryk.vico.core.chart.segment.MutableSegmentProperties
 import com.patrykandpatryk.vico.core.chart.segment.SegmentProperties
@@ -64,11 +65,13 @@ import kotlin.math.min
  * @param targetVerticalAxisPosition if this is set, any [com.patrykandpatryk.vico.core.axis.AxisRenderer] with an
  * [AxisPosition] equal to the provided value will use the [ChartValues] provided by this chart.
  * This is meant to be used with [com.patrykandpatryk.vico.core.chart.composed.ComposedChart].
+ * @param pointPosition the horizontal position of each point in its corresponding segment.
  */
 public open class LineChart(
     public var lines: List<LineSpec> = listOf(LineSpec()),
     public var spacingDp: Float = DefaultDimens.POINT_SPACING,
     public var targetVerticalAxisPosition: AxisPosition.Vertical? = null,
+    public var pointPosition: PointPosition = PointPosition.Center,
 ) : BaseChart<ChartEntryModel>() {
 
     /**
@@ -79,12 +82,14 @@ public open class LineChart(
      * @param targetVerticalAxisPosition if this is set, any [com.patrykandpatryk.vico.core.axis.AxisRenderer] with an
      * [AxisPosition] equal to the provided value will use the [ChartValues] provided by this chart.
      * This is meant to be used with [com.patrykandpatryk.vico.core.chart.composed.ComposedChart].
+     * @param pointPosition the horizontal position of each point in its corresponding segment.
      */
     public constructor(
         line: LineSpec,
         spacingDp: Float,
         targetVerticalAxisPosition: AxisPosition.Vertical? = null,
-    ) : this(listOf(line), spacingDp, targetVerticalAxisPosition)
+        pointPosition: PointPosition = PointPosition.Center,
+    ) : this(listOf(line), spacingDp, targetVerticalAxisPosition, pointPosition)
 
     /**
      * Defines the appearance of a line in a line chart.
@@ -99,7 +104,6 @@ public open class LineChart(
      * @param dataLabelVerticalPosition the vertical position of data labels relative to the line.
      * @param dataLabelValueFormatter the [ValueFormatter] to use for data labels.
      * @param dataLabelRotationDegrees the rotation of data labels in degrees.
-     * @param pointPosition the horizontal position of each point in its corresponding segment.
      * @param pointConnector the [PointConnector] for the line.
      */
     public open class LineSpec(
@@ -113,7 +117,6 @@ public open class LineChart(
         public var dataLabelVerticalPosition: VerticalPosition = VerticalPosition.Top,
         public var dataLabelValueFormatter: ValueFormatter = DecimalFormatValueFormatter(),
         public var dataLabelRotationDegrees: Float = 0f,
-        public var pointPosition: PointPosition = PointPosition.Center,
         public var pointConnector: PointConnector = DefaultPointConnector(),
     ) {
 
@@ -131,7 +134,6 @@ public open class LineChart(
          * @param dataLabelVerticalPosition the vertical position of data labels relative to the line.
          * @param dataLabelValueFormatter the [ValueFormatter] to use for data labels.
          * @param dataLabelRotationDegrees the rotation of data labels in degrees.
-         * @param pointPosition the horizontal position of each point in its corresponding segment.
          */
         @Deprecated(
             message = """Rather than using this constructor and its `cubicStrength` parameter, use the primary
@@ -167,7 +169,6 @@ public open class LineChart(
             dataLabelVerticalPosition: VerticalPosition = VerticalPosition.Top,
             dataLabelValueFormatter: ValueFormatter = DecimalFormatValueFormatter(),
             dataLabelRotationDegrees: Float = 0f,
-            pointPosition: PointPosition = PointPosition.Center,
         ) : this(
             lineColor = lineColor,
             lineThicknessDp = lineThicknessDp,
@@ -179,7 +180,6 @@ public open class LineChart(
             dataLabelVerticalPosition = dataLabelVerticalPosition,
             dataLabelValueFormatter = dataLabelValueFormatter,
             dataLabelRotationDegrees = dataLabelRotationDegrees,
-            pointPosition = pointPosition,
             pointConnector = DefaultPointConnector(cubicStrength = cubicStrength),
         )
 
@@ -245,14 +245,6 @@ public open class LineChart(
         }
 
         /**
-         * Defines the horizontal position of each point in its corresponding segment.
-         */
-        public enum class PointPosition(internal val position: HorizontalPosition) {
-            Start(position = HorizontalPosition.Start),
-            Center(position = HorizontalPosition.Center),
-        }
-
-        /**
          * Defines the shape of a line in a line chart by specifying how points are to be connected.
          *
          * @see DefaultPointConnector
@@ -300,9 +292,9 @@ public open class LineChart(
             var prevY = bounds.bottom
 
             val drawingStartAlignmentCorrection = layoutDirectionMultiplier *
-                when (component.pointPosition) {
-                    LineSpec.PointPosition.Start -> 0f
-                    LineSpec.PointPosition.Center -> (spacing + cellWidth).half
+                when (pointPosition) {
+                    PointPosition.Start -> 0f
+                    PointPosition.Center -> (spacing + cellWidth).half
                 }
 
             val drawingStart = bounds.getStart(isLtr = isLtr) + drawingStartAlignmentCorrection - horizontalScroll
@@ -520,5 +512,13 @@ public open class LineChart(
                 else it.lineThicknessDp
             }.pixels,
         )
+    }
+
+    /**
+     * Defines the horizontal position of each point in its corresponding segment.
+     */
+    public enum class PointPosition(internal val position: HorizontalPosition) {
+        Start(position = HorizontalPosition.Start),
+        Center(position = HorizontalPosition.Center),
     }
 }

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/segment/MutableSegmentProperties.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/segment/MutableSegmentProperties.kt
@@ -34,11 +34,10 @@ public data class MutableSegmentProperties(
         cellWidth: Float,
         marginWidth: Float,
         labelPosition: HorizontalAxis.LabelPosition? = this.labelPosition,
-    ): MutableSegmentProperties {
+    ): MutableSegmentProperties = apply {
         this.cellWidth = cellWidth
         this.marginWidth = marginWidth
         this.labelPosition = labelPosition
-        return this
     }
 
     /**

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/segment/MutableSegmentProperties.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/segment/MutableSegmentProperties.kt
@@ -16,20 +16,28 @@
 
 package com.patrykandpatryk.vico.core.chart.segment
 
+import com.patrykandpatryk.vico.core.axis.horizontal.HorizontalAxis
+
 /**
  * An implementation of [SegmentProperties] whose every property is mutable.
  */
 public data class MutableSegmentProperties(
     override var cellWidth: Float = 0f,
     override var marginWidth: Float = 0f,
+    override var labelPosition: HorizontalAxis.LabelPosition? = null,
 ) : SegmentProperties {
 
     /**
      * Sets a cell width and margin width.
      */
-    public fun set(cellWidth: Float, marginWidth: Float): MutableSegmentProperties {
+    public fun set(
+        cellWidth: Float,
+        marginWidth: Float,
+        labelPosition: HorizontalAxis.LabelPosition? = this.labelPosition,
+    ): MutableSegmentProperties {
         this.cellWidth = cellWidth
         this.marginWidth = marginWidth
+        this.labelPosition = labelPosition
         return this
     }
 

--- a/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/segment/SegmentProperties.kt
+++ b/vico/core/src/main/java/com/patrykandpatryk/vico/core/chart/segment/SegmentProperties.kt
@@ -16,6 +16,8 @@
 
 package com.patrykandpatryk.vico.core.chart.segment
 
+import com.patrykandpatryk.vico.core.axis.horizontal.HorizontalAxis
+
 /**
  * [SegmentProperties] holds information about the dimensions of a segment on an x-axis.
  */
@@ -38,6 +40,18 @@ public interface SegmentProperties {
         get() = cellWidth + marginWidth
 
     /**
+     * Defines the position of labels.
+     */
+    public val labelPosition: HorizontalAxis.LabelPosition?
+
+    /**
+     * Defines the position of labels.
+     * Returns [labelPosition] if it’s not null, and [HorizontalAxis.LabelPosition.Center] otherwise.
+     */
+    public val labelPositionOrDefault: HorizontalAxis.LabelPosition
+        get() = labelPosition ?: HorizontalAxis.LabelPosition.Center
+
+    /**
      * @see cellWidth
      */
     public operator fun component1(): Float = cellWidth
@@ -48,16 +62,15 @@ public interface SegmentProperties {
     public operator fun component2(): Float = marginWidth
 
     /**
-     * @see segmentWidth
-     */
-    public operator fun component3(): Float = segmentWidth
-
-    /**
      * Creates a new [SegmentProperties] implementation by multiplying the cell width
      * and margin width from these [SegmentProperties] by the provided factor.
      */
     public fun scaled(scale: Float): SegmentProperties =
-        SegmentProperties(cellWidth * scale, marginWidth * scale)
+        SegmentProperties(
+            cellWidth = cellWidth * scale,
+            marginWidth = marginWidth * scale,
+            labelPosition = labelPosition,
+        )
 }
 
 /**
@@ -66,7 +79,15 @@ public interface SegmentProperties {
  * @param cellWidth the width of each individual cell (e.g., a column in a column chart or a point in a line chart).
  * @param marginWidth the sum of the cell width and margin width.
  */
-public fun SegmentProperties(cellWidth: Float, marginWidth: Float): SegmentProperties = object : SegmentProperties {
+public fun SegmentProperties(
+    cellWidth: Float,
+    marginWidth: Float,
+    labelPosition: HorizontalAxis.LabelPosition?,
+): SegmentProperties = object : SegmentProperties {
+
     override val cellWidth: Float = cellWidth
+
     override val marginWidth: Float = marginWidth
+
+    override val labelPosition: HorizontalAxis.LabelPosition? = labelPosition
 }

--- a/vico/view/src/main/java/com/patrykandpatryk/vico/view/theme/ChartStyleExtensions.kt
+++ b/vico/view/src/main/java/com/patrykandpatryk/vico/view/theme/ChartStyleExtensions.kt
@@ -135,5 +135,9 @@ internal fun TypedArray.getLineChart(
             index = R.styleable.LineChartStyle_spacing,
             defaultValue = DefaultDimens.POINT_SPACING,
         ),
+        pointPosition = getInteger(R.styleable.LineChartStyle_pointPosition, 1).let { value ->
+            val values = LineChart.PointPosition.values()
+            values[value % values.size]
+        },
     )
 }

--- a/vico/view/src/main/java/com/patrykandpatryk/vico/view/theme/ComponentStyleExtensions.kt
+++ b/vico/view/src/main/java/com/patrykandpatryk/vico/view/theme/ComponentStyleExtensions.kt
@@ -184,10 +184,6 @@ internal fun TypedArray.getLineSpec(
             R.styleable.LineSpec_dataLabelRotationDegrees,
             0f,
         ),
-        pointPosition = getInteger(R.styleable.LineSpec_pointPosition, 1).let { value ->
-            val values = LineChart.LineSpec.PointPosition.values()
-            values[value % values.size]
-        },
         pointConnector = DefaultPointConnector(
             cubicStrength = getFraction(
                 index = R.styleable.LineSpec_cubicStrength,

--- a/vico/view/src/main/java/com/patrykandpatryk/vico/view/theme/ThemeHandler.kt
+++ b/vico/view/src/main/java/com/patrykandpatryk/vico/view/theme/ThemeHandler.kt
@@ -182,11 +182,6 @@ internal class ThemeHandler(
                             spacing = axisStyle.getInteger(R.styleable.Axis_horizontalAxisTickSpacing, 1),
                         )
                     }
-
-                    labelPosition = axisStyle.getInteger(R.styleable.Axis_horizontalAxisLabelPosition, 1).let { value ->
-                        val values = HorizontalAxis.LabelPosition.values()
-                        values[value % values.size]
-                    }
                 }
             }
         }.also { axisStyle.recycle() }

--- a/vico/view/src/main/res/values/attrs.xml
+++ b/vico/view/src/main/res/values/attrs.xml
@@ -84,10 +84,6 @@
         </attr>
         <attr name="horizontalAxisTickOffset" format="integer" />
         <attr name="horizontalAxisTickSpacing" format="integer" />
-        <attr name="horizontalAxisLabelPosition" format="enum">
-            <enum name="start" value="0" />
-            <enum name="center" value="1" />
-        </attr>
     </declare-styleable>
 
     <declare-styleable name="LineComponent">

--- a/vico/view/src/main/res/values/line_chart_attrs.xml
+++ b/vico/view/src/main/res/values/line_chart_attrs.xml
@@ -25,6 +25,10 @@
         <attr name="line2Spec" />
         <attr name="line3Spec" />
         <attr name="spacing" format="dimension" />
+        <attr name="pointPosition" format="enum">
+            <enum name="start" value="0" />
+            <enum name="center" value="1" />
+        </attr>
     </declare-styleable>
 
     <declare-styleable name="LineSpec">
@@ -39,10 +43,6 @@
         <attr name="dataLabelStyle" />
         <attr name="dataLabelVerticalPosition" />
         <attr name="dataLabelRotationDegrees" />
-        <attr name="pointPosition" format="enum">
-            <enum name="start" value="0" />
-            <enum name="center" value="1" />
-        </attr>
     </declare-styleable>
 
     <declare-styleable name="ComponentStyle">


### PR DESCRIPTION
1. Move `LineSpec.PointPosition` to upper level `LineChart`, as having multiple `LineSpec`s with different `PointPosition` is pointless.
2. Make the `LineChart` control a `labelPosition` in `HorizontalAxis`, instead of relying on a manual setting. 