### PR TITLE
[Sample] Add ability to click on arrows within SwipeHint

### DIFF
--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
@@ -99,7 +99,7 @@ internal fun ChartPager(
                     currentPage = state.currentValue + 1,
                     pageCount = itemCount,
                 ) { direction ->
-                    val newState = (state.currentValue + direction)
+                    val newState = state.currentValue + direction
                     if (newState in 0 until itemCount) {
                         scope.launch { state.animateTo(newState) }
                     }

--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.SwipeableState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -37,6 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.patrykandpatryk.vico.sample.util.SampleChart
 import com.patrykandpatryk.vico.sample.util.Tab
+import kotlinx.coroutines.launch
 
 @Composable
 @OptIn(ExperimentalMaterialApi::class)
@@ -46,6 +48,8 @@ internal fun ChartPager(
     sampleCharts: List<SampleChart>,
     tab: Tab,
 ) {
+    val scope = rememberCoroutineScope()
+
     HorizontalPager(
         state = state,
         itemCount = itemCount,
@@ -93,8 +97,11 @@ internal fun ChartPager(
             ) {
                 SwipeHint(
                     currentPage = state.currentValue + 1,
-                    pageCount = itemCount,
-                )
+                    pageCount = itemCount
+                ) { direction: Int ->
+                    val newState = (state.currentValue + direction).coerceIn(0 until itemCount)
+                    scope.launch { state.animateTo(newState) }
+                }
             }
         },
     ) {

--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
@@ -97,7 +97,7 @@ internal fun ChartPager(
             ) {
                 SwipeHint(
                     currentPage = state.currentValue + 1,
-                    pageCount = itemCount
+                    pageCount = itemCount,
                 ) { direction ->
                     val newState = (state.currentValue + direction)
                     if (newState in 0 until itemCount) {

--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
@@ -98,7 +98,7 @@ internal fun ChartPager(
                 SwipeHint(
                     currentPage = state.currentValue + 1,
                     pageCount = itemCount
-                ) { direction: Int ->
+                ) { direction ->
                     val newState = (state.currentValue + direction).coerceIn(0 until itemCount)
                     scope.launch { state.animateTo(newState) }
                 }

--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/ChartPager.kt
@@ -99,8 +99,10 @@ internal fun ChartPager(
                     currentPage = state.currentValue + 1,
                     pageCount = itemCount
                 ) { direction ->
-                    val newState = (state.currentValue + direction).coerceIn(0 until itemCount)
-                    scope.launch { state.animateTo(newState) }
+                    val newState = (state.currentValue + direction)
+                    if (newState in 0 until itemCount) {
+                        scope.launch { state.animateTo(newState) }
+                    }
                 }
             }
         },

--- a/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/SwipeHint.kt
+++ b/sample/src/main/java/com/patrykandpatryk/vico/sample/ui/SwipeHint.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -36,6 +37,7 @@ import com.patrykandpatryk.vico.R
 internal fun SwipeHint(
     currentPage: Int,
     pageCount: Int,
+    onArrowClick: (direction: Int) -> Unit,
 ) {
     Row(
         horizontalArrangement = Arrangement.Center,
@@ -44,11 +46,13 @@ internal fun SwipeHint(
             .padding(vertical = 32.dp)
             .fillMaxWidth(),
     ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_caret_left),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        IconButton(onClick = { onArrowClick(DIRECTION_BACKWARD) }) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_caret_left),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         Column(
             modifier = Modifier.padding(horizontal = 12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -65,10 +69,15 @@ internal fun SwipeHint(
                 modifier = Modifier.padding(top = 2.dp),
             )
         }
-        Icon(
-            painter = painterResource(id = R.drawable.ic_caret_right),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        IconButton(onClick = { onArrowClick(DIRECTION_FORWARD) }) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_caret_right),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
+
+private const val DIRECTION_FORWARD = 1
+private const val DIRECTION_BACKWARD = -1


### PR DESCRIPTION
This PR adds the ability to click on arrows within the `SwipeHint` (located below the charts in the sample.) While this isn't the most useful PR of all, it fixes a small confusion I've had multiple times while trying out the sample app.

The ability to swipe between pages remains available and the ability to click the arrows does not break it.