### PR TITLE
Replace Compose Stable Marker with `androidx.compose.runtime:runtime-annotation`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ appcompat = "1.7.1"
 composeBom = "2025.09.00"
 composeMultiplatform = "1.9.0"
 composeNavigation = "2.9.0"
-composeStableMarker = "1.0.7"
 coroutines = "1.10.2"
 dateTime = "0.7.1"
 dokka = "2.1.0"
@@ -35,7 +34,7 @@ composeMaterial3 = { group = "androidx.compose.material3", name = "material3" }
 composeMultiplatform = { group = "org.jetbrains.compose", name = "compose-gradle-plugin", version.ref = "composeMultiplatform" }
 composeNavigation = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "composeNavigation" }
 composePreview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-composeStableMarker = { group = "com.github.skydoves", name = "compose-stable-marker", version.ref = "composeStableMarker" }
+composeRuntimeAnnotation = { group = "androidx.compose.runtime", name = "runtime-annotation" }
 composeUI = { group = "androidx.compose.ui", name = "ui" }
 composeUITooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 composeViewBinding = { group = "androidx.compose.ui", name = "ui-viewbinding" }

--- a/vico/core/build.gradle.kts
+++ b/vico/core/build.gradle.kts
@@ -37,10 +37,11 @@ kotlin {
 }
 
 dependencies {
+  compileOnly(platform(libs.composeBom))
+  compileOnly(libs.composeRuntimeAnnotation)
   implementation(libs.androidXAnnotation)
   implementation(libs.coroutinesCore)
   implementation(libs.kotlinStdLib)
-  compileOnly(libs.composeStableMarker)
   testImplementation(libs.jupiter)
   testImplementation(libs.jupiterParams)
   testImplementation(libs.kotlinTest)


### PR DESCRIPTION
## Summary
- remove the explicit version for androidx.compose.runtime:runtime-annotation from the version catalog so it can follow the Compose BOM
- add the Compose BOM to the core module's compileOnly configuration and place it before the runtime annotation dependency for clarity

## Testing
- ./gradlew :vico:core:testDebugUnitTest --console=plain --stacktrace

------
https://chatgpt.com/codex/tasks/task_e_68fe6d4e530883308b3ed117e6334ced