### PR TITLE
Add NaN check for limitedCanvasY in LineCartesianLayer

### DIFF
--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/LineCartesianLayer.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/LineCartesianLayer.kt
@@ -457,6 +457,7 @@ protected constructor(
   ) {
     if (canvasX <= layerBounds.left - 1 || canvasX >= layerBounds.right + 1) return
     val limitedCanvasY = canvasY.coerceIn(layerBounds.top, layerBounds.bottom)
+    if (limitedCanvasY.isNaN()) return
     _markerTargets
       .getOrPut(entry.x) { listOf(MutableLineCartesianLayerMarkerTarget(entry.x, canvasX)) }
       .first()


### PR DESCRIPTION
The library crashes when trying to round NaN values during marker position calculations in Jetpack Compose:

```
java.lang.IllegalArgumentException: Cannot round NaN value.
	at kotlin.math.MathKt__MathJVMKt.roundToInt(MathJVM.kt:1192)
	at com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer.updateMarkerTargets(LineCartesianLayer.kt:471)
	at com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer.drawInternal$lambda$0$0$1(LineCartesianLayer.kt:442)
	at com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer.$r8$lambda$xv2kDzlA_53Sm7FKzzFTWsrRVN0(Unknown Source:0)
	at com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer$$ExternalSyntheticLambda1.invoke(D8$$SyntheticClass:0)
	at com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer.forEachPointInBounds(LineCartesianLayer.kt:612)
	at com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer.forEachPointInBounds$default(LineCartesianLayer.kt:567)
	at com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer.drawInternal(LineCartesianLayer.kt:441)
	at com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer.drawInternal(LineCartesianLayer.kt:77)
	at com.patrykandpatrick.vico.core.cartesian.layer.BaseCartesianLayer.draw(BaseCartesianLayer.kt:39)
	at com.patrykandpatrick.vico.core.cartesian.CartesianChart$drawingConsumer$1.invoke(CartesianChart.kt:96)
	at com.patrykandpatrick.vico.core.cartesian.CartesianChart.forEachWithLayer(CartesianChart.kt:605)
	at com.patrykandpatrick.vico.core.cartesian.CartesianChart.draw$lambda$0$1(CartesianChart.kt:317)
	at com.patrykandpatrick.vico.core.cartesian.CartesianChart.$r8$lambda$cnxcw9PVmZSEv3eUvT6oaEfe5Rg(Unknown Source:0)
	at com.patrykandpatrick.vico.core.cartesian.CartesianChart$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0)
	at com.patrykandpatrick.vico.core.cartesian.CartesianDrawingContextKt$CartesianDrawingContext$1.withCanvas(CartesianDrawingContext.kt:89)
	at com.patrykandpatrick.vico.core.cartesian.CartesianChart.draw(CartesianChart.kt:316)
	at com.patrykandpatrick.vico.compose.cartesian.CartesianChartHostKt.CartesianChartHostImpl$lambda$18$0(CartesianChartHost.kt:284)
	at com.patrykandpatrick.vico.compose.cartesian.CartesianChartHostKt.$r8$lambda$kbOid5RiejKC1Cb1jATIkCBLmQg(Unknown Source:0)
	at com.patrykandpatrick.vico.compose.cartesian.CartesianChartHostKt$$ExternalSyntheticLambda7.invoke(D8$$SyntheticClass:0)
	at androidx.compose.ui.draw.DrawBackgroundModifier.draw(DrawModifier.kt:126)
	at androidx.compose.ui.node.LayoutNodeDrawScope.drawDirect-eZhPAX0$ui_release(LayoutNodeDrawScope.kt:132)
	at androidx.compose.ui.node.LayoutNodeDrawScope.draw-eZhPAX0$ui_release(LayoutNodeDrawScope.kt:119)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:460)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.performDraw(LayoutModifierNodeCoordinator.kt:271)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutNode.draw$ui_release(LayoutNode.kt:1054)
	at androidx.compose.ui.node.InnerNodeCoordinator.performDraw(InnerNodeCoordinator.kt:177)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.performDraw(LayoutModifierNodeCoordinator.kt:271)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.performDraw(LayoutModifierNodeCoordinator.kt:271)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.performDraw(LayoutModifierNodeCoordinator.kt:271)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutNode.draw$ui_release(LayoutNode.kt:1054)
	at androidx.compose.ui.node.InnerNodeCoordinator.performDraw(InnerNodeCoordinator.kt:177)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.performDraw(LayoutModifierNodeCoordinator.kt:271)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.performDraw(LayoutModifierNodeCoordinator.kt:271)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutNode.draw$ui_release(LayoutNode.kt:1054)
	at androidx.compose.ui.node.InnerNodeCoordinator.performDraw(InnerNodeCoordinator.kt:177)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.performDraw(LayoutModifierNodeCoordinator.kt:271)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.performDraw(LayoutModifierNodeCoordinator.kt:271)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutNode.draw$ui_release(LayoutNode.kt:1054)
	at androidx.compose.ui.node.InnerNodeCoordinator.performDraw(InnerNodeCoordinator.kt:177)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.draw(NodeCoordinator.kt:449)
	at androidx.compose.ui.node.LayoutNode.draw$ui_release(LayoutNode.kt:1054)
	at androidx.compose.ui.node.InnerNodeCoordinator.performDraw(InnerNodeCoordinator.kt:177)
	at androidx.compose.ui.node.NodeCoordinator.drawContainedDrawModifiers(NodeCoordinator.kt:457)
	at androidx.compose.ui.node.NodeCoordinator.access$drawContainedDrawModifiers(NodeCoordinator.kt:65)
	at androidx.compose.ui.node.NodeCoordinator$drawBlock$drawBlockCallToDrawModifiers$1.invoke(NodeCoordinator.kt:483)
	at androidx.compose.ui.node.NodeCoordinator$drawBlock$drawBlockCallToDrawModifiers$1.invoke(NodeCoordinator.kt:482)
	at androidx.compose.runtime.snapshots.Snapshot$Companion.observe(Snapshot.kt:2495)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver$ObservedScopeMap.observe(SnapshotStateObserver.kt:464)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:248)
	at androidx.compose.ui.node.OwnerSnapshotObserver.observeReads$ui_release(OwnerSnapshotObserver.kt:124)
	at androidx.compose.ui.node.NodeCoordinator$drawBlock$1.invoke(NodeCoordinator.kt:489)
	at androidx.compose.ui.node.NodeCoordinator$drawBlock$1.invoke(NodeCoordinator.kt:485)
	at androidx.compose.ui.platform.GraphicsLayerOwnerLayer$recordLambda$1.invoke(GraphicsLayerOwnerLayer.android.kt:276)
	at androidx.compose.ui.platform.GraphicsLayerOwnerLayer$recordLambda$1.invoke(GraphicsLayerOwnerLayer.android.kt:274)
	at androidx.compose.ui.graphics.layer.GraphicsLayer.drawWithChildTracking(AndroidGraphicsLayer.android.kt:438)
	at androidx.compose.ui.graphics.layer.GraphicsLayer.access$drawWithChildTracking(AndroidGraphicsLayer.android.kt:55) 
	at androidx.compose.ui.graphics.layer.GraphicsLayer$clipDrawBlock$1.invoke(AndroidGraphicsLayer.android.kt:68)
	at androidx.compose.ui.graphics.layer.GraphicsLayer$clipDrawBlock$1.invoke(AndroidGraphicsLayer.android.kt:63)
	at androidx.compose.ui.graphics.layer.GraphicsLayerV29.record(GraphicsLayerV29.android.kt:251)
	at androidx.compose.ui.graphics.layer.GraphicsLayer.recordInternal(AndroidGraphicsLayer.android.kt:431)
	at androidx.compose.ui.graphics.layer.GraphicsLayer.record-mL-hObY(AndroidGraphicsLayer.android.kt:427)
	at androidx.compose.ui.platform.GraphicsLayerOwnerLayer.updateDisplayList(GraphicsLayerOwnerLayer.android.kt:269)
	at androidx.compose.ui.platform.AndroidComposeView.dispatchDraw(AndroidComposeView.android.kt:1916)
	at android.view.View.draw(View.java:25287)
	at android.view.View.updateDisplayListIfDirty(View.java:24130)
	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4556)
	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4529)
	at android.view.View.updateDisplayListIfDirty(View.java:24084)
	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4556)
	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4529)
	at android.view.View.updateDisplayListIfDirty(View.java:24084)
	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4556)
	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4529)
	at android.view.View.updateDisplayListIfDirty(View.java:24084)
	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4556)
	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4529)
	at android.view.View.updateDisplayListIfDirty(View.java:24084)
	at android.view.ThreadedRenderer.updateViewTreeDisplayList(ThreadedRenderer.java:694)
	at android.view.ThreadedRenderer.updateRootDisplayList(ThreadedRenderer.java:700)
	at android.view.ThreadedRenderer.draw(ThreadedRenderer.java:798)
	at android.view.ViewRootImpl.draw(ViewRootImpl.java:5839)
	at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:5490)
	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:4474)
	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:3071)
	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:10659)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1570)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1579)
	at android.view.Choreographer.doCallbacks(Choreographer.java:1179)
	at android.view.Choreographer.doFrame(Choreographer.java:1108)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1553)
	at android.os.Handler.handleCallback(Handler.java:1041)
	at android.os.Handler.dispatchMessage(Handler.java:103)
	at android.os.Looper.dispatchMessage(Looper.java:315)
	at android.os.Looper.loopOnce(Looper.java:251)
	at android.os.Looper.loop(Looper.java:349)
	at android.app.ActivityThread.main(ActivityThread.java:9041)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```