### PR TITLE
Improve `PointerInputChange` consumption logic

### DIFF
--- a/vico/compose/build.gradle.kts
+++ b/vico/compose/build.gradle.kts
@@ -62,7 +62,9 @@ kotlin {
     val androidHostTest by getting { dependencies { implementation(libs.mockK) } }
   }
   explicitApi()
-  compilerOptions { freeCompilerArgs.add("-Xannotation-default-target=param-property") }
+  compilerOptions {
+    freeCompilerArgs.addAll("-Xannotation-default-target=param-property", "-Xcontext-parameters")
+  }
 }
 
 /*

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -190,6 +190,9 @@ internal fun CartesianChartHostImpl(
               markerX = null
               markerSeriesIndex = null
             }
+            true
+          } else {
+            false
           }
         }
       } else {

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.util.fastForEach
 import com.patrykandpatrick.vico.compose.cartesian.marker.Interaction
 import com.patrykandpatrick.vico.compose.common.Point
 import com.patrykandpatrick.vico.compose.common.detectZoomGestures
@@ -46,7 +47,7 @@ private fun Offset.toPoint() = Point(x, y)
 @Composable
 internal fun Modifier.pointerInput(
   scrollState: VicoScrollState,
-  onInteraction: ((Interaction) -> Unit)?,
+  onInteraction: ((Interaction) -> Boolean)?,
   onZoom: ((Float, Offset) -> Unit)?,
   consumeMoveEvents: Boolean,
   longPressEnabled: Boolean,
@@ -63,27 +64,36 @@ internal fun Modifier.pointerInput(
           val event = awaitPointerEvent()
           val position = event.changes.first().position
           val pointerPosition = position.toPoint()
-          when {
-            event.type == PointerEventType.Scroll && scrollState.scrollEnabled && onZoom != null ->
-              onZoom(
-                1 - event.changes.first().scrollDelta.y * BASE_SCROLL_ZOOM_DELTA,
-                event.changes.first().position,
-              )
-            onInteraction == null -> continue
-            event.type == PointerEventType.Press && event.changes.size == 1 ->
-              onInteraction(Interaction.Press(pointerPosition))
-            event.type == PointerEventType.Release || event.type == PointerEventType.Press ->
-              onInteraction(Interaction.Release(pointerPosition))
-            event.type == PointerEventType.Move -> {
-              if (consumeMoveEvents && !scrollState.scrollEnabled) event.changes.first().consume()
-              onInteraction(Interaction.Move(pointerPosition))
+          val consume =
+            when {
+              event.type == PointerEventType.Scroll &&
+                scrollState.scrollEnabled &&
+                onZoom != null -> {
+                onZoom(
+                  1 - event.changes.first().scrollDelta.y * BASE_SCROLL_ZOOM_DELTA,
+                  event.changes.first().position,
+                )
+                true
+              }
+              onInteraction == null -> continue
+              event.type == PointerEventType.Press && event.changes.size == 1 ->
+                onInteraction(Interaction.Press(pointerPosition))
+              event.type == PointerEventType.Release || event.type == PointerEventType.Press ->
+                onInteraction(Interaction.Release(pointerPosition))
+              event.type == PointerEventType.Move -> {
+                val consume = consumeMoveEvents && !scrollState.scrollEnabled
+                onInteraction(Interaction.Move(pointerPosition)) && consume
+              }
+              event.type == PointerEventType.Enter ->
+                onInteraction(Interaction.Enter(pointerPosition))
+              event.type == PointerEventType.Exit -> {
+                val isInsideChartBounds = position.fits(size)
+                onInteraction(Interaction.Exit(pointerPosition, isInsideChartBounds))
+              }
+              else -> false
             }
-            event.type == PointerEventType.Enter ->
-              onInteraction(Interaction.Enter(pointerPosition))
-            event.type == PointerEventType.Exit -> {
-              val isInsideChartBounds = position.fits(size)
-              onInteraction(Interaction.Exit(pointerPosition, isInsideChartBounds))
-            }
+          if (consume) {
+            event.changes.fastForEach { it.consume() }
           }
         }
       }
@@ -91,7 +101,7 @@ internal fun Modifier.pointerInput(
     .then(
       if (onInteraction != null) {
         Modifier.pointerInput(onInteraction, longPressEnabled) {
-          detectTapGesturesWithoutConsume(
+          detectTapGestures(
             onTap = { onInteraction(Interaction.Tap(it.toPoint())) },
             onLongPress =
               if (longPressEnabled) {
@@ -119,16 +129,18 @@ internal fun Modifier.pointerInput(
     )
     .extraPointerInput(scrollState)
 
-private suspend fun PointerInputScope.detectTapGesturesWithoutConsume(
-  onTap: (Offset) -> Unit,
-  onLongPress: ((Offset) -> Unit)?,
+private suspend fun PointerInputScope.detectTapGestures(
+  onTap: (Offset) -> Boolean,
+  onLongPress: ((Offset) -> Boolean)?,
 ) {
   awaitEachGesture {
     val down = awaitFirstDown()
     if (onLongPress != null) {
       val longPress = awaitLongPressOrCancellation(down.id)
       if (longPress != null) {
-        onLongPress(longPress.position)
+        if (onLongPress(longPress.position)) {
+          longPress.consume()
+        }
         return@awaitEachGesture
       }
     } else {
@@ -136,7 +148,9 @@ private suspend fun PointerInputScope.detectTapGesturesWithoutConsume(
     }
     val inputChange = currentEvent.changes.firstOrNull()
     if (inputChange.isTap(down)) {
-      onTap(inputChange.position)
+      if (onTap(inputChange.position)) {
+        inputChange.consume()
+      }
     }
   }
 }
@@ -148,7 +162,7 @@ private fun PointerInputChange?.isTap(firstDown: PointerInputChange): Boolean {
   this ?: return false
   val longPressTimeoutMillis = pointerEventScope.viewConfiguration.longPressTimeoutMillis
   val touchSlop = pointerEventScope.viewConfiguration.touchSlop
-  val isNotLongPress = previousUptimeMillis - uptimeMillis < longPressTimeoutMillis
+  val isNotLongPress = uptimeMillis - previousUptimeMillis < longPressTimeoutMillis
   val isNotMove = (firstDown.position - position).getDistance() < touchSlop
   return !pressed && previousPressed && isNotLongPress && isNotMove
 }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
@@ -76,13 +76,17 @@ internal fun Modifier.pointerInput(
                 true
               }
               onInteraction == null -> continue
-              event.type == PointerEventType.Press && event.changes.size == 1 ->
+              event.type == PointerEventType.Press && event.changes.size == 1 -> {
                 onInteraction(Interaction.Press(pointerPosition))
-              event.type == PointerEventType.Release || event.type == PointerEventType.Press ->
+                false
+              }
+              event.type == PointerEventType.Release || event.type == PointerEventType.Press -> {
                 onInteraction(Interaction.Release(pointerPosition))
+                false
+              }
               event.type == PointerEventType.Move -> {
-                val consume = consumeMoveEvents && !scrollState.scrollEnabled
-                onInteraction(Interaction.Move(pointerPosition)) && consume
+                onInteraction(Interaction.Move(pointerPosition))
+                consumeMoveEvents && !scrollState.scrollEnabled
               }
               event.type == PointerEventType.Enter ->
                 onInteraction(Interaction.Enter(pointerPosition))
@@ -135,18 +139,19 @@ private suspend fun PointerInputScope.detectTapGestures(
 ) {
   awaitEachGesture {
     val down = awaitFirstDown()
-    if (onLongPress != null) {
-      val longPress = awaitLongPressOrCancellation(down.id)
-      if (longPress != null) {
-        if (onLongPress(longPress.position)) {
-          longPress.consume()
+    val inputChange =
+      if (onLongPress != null) {
+        val longPress = awaitLongPressOrCancellation(down.id)
+        if (longPress != null) {
+          if (onLongPress(longPress.position)) {
+            longPress.consume()
+          }
+          return@awaitEachGesture
         }
-        return@awaitEachGesture
+        currentEvent.changes.firstOrNull { it.id == down.id }
+      } else {
+        waitForUpOrCancellation()
       }
-    } else {
-      waitForUpOrCancellation()
-    }
-    val inputChange = currentEvent.changes.firstOrNull()
     if (inputChange.isTap(down)) {
       if (onTap(inputChange.position)) {
         inputChange.consume()
@@ -162,7 +167,7 @@ private fun PointerInputChange?.isTap(firstDown: PointerInputChange): Boolean {
   this ?: return false
   val longPressTimeoutMillis = pointerEventScope.viewConfiguration.longPressTimeoutMillis
   val touchSlop = pointerEventScope.viewConfiguration.touchSlop
-  val isNotLongPress = uptimeMillis - previousUptimeMillis < longPressTimeoutMillis
+  val isNotLongPress = uptimeMillis - firstDown.uptimeMillis < longPressTimeoutMillis
   val isNotMove = (firstDown.position - position).getDistance() < touchSlop
   return !pressed && previousPressed && isNotLongPress && isNotMove
 }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
@@ -143,20 +143,14 @@ private suspend fun PointerInputScope.detectTapGestures(
       if (onLongPress != null) {
         val longPress = awaitLongPressOrCancellation(down.id)
         if (longPress != null) {
-          if (onLongPress(longPress.position)) {
-            longPress.consume()
-          }
+          if (onLongPress(longPress.position)) longPress.consume()
           return@awaitEachGesture
         }
         currentEvent.changes.firstOrNull { it.id == down.id }
       } else {
         waitForUpOrCancellation()
       }
-    if (inputChange.isTap(down)) {
-      if (onTap(inputChange.position)) {
-        inputChange.consume()
-      }
-    }
+    if (inputChange.isTap(down) && onTap(inputChange.position)) inputChange.consume()
   }
 }
 
@@ -164,7 +158,7 @@ private suspend fun PointerInputScope.detectTapGestures(
 context(pointerEventScope: AwaitPointerEventScope)
 private fun PointerInputChange?.isTap(firstDown: PointerInputChange): Boolean {
   contract { returns(true).implies(this@isTap != null) }
-  this ?: return false
+  if (this == null) return false
   val longPressTimeoutMillis = pointerEventScope.viewConfiguration.longPressTimeoutMillis
   val touchSlop = pointerEventScope.viewConfiguration.touchSlop
   val isNotLongPress = uptimeMillis - firstDown.uptimeMillis < longPressTimeoutMillis

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
@@ -17,17 +17,25 @@
 package com.patrykandpatrick.vico.compose.cartesian
 
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
 import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntSize
 import com.patrykandpatrick.vico.compose.cartesian.marker.Interaction
 import com.patrykandpatrick.vico.compose.common.Point
 import com.patrykandpatrick.vico.compose.common.detectZoomGestures
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 private const val BASE_SCROLL_ZOOM_DELTA = 0.1f
 
@@ -83,14 +91,14 @@ internal fun Modifier.pointerInput(
     .then(
       if (onInteraction != null) {
         Modifier.pointerInput(onInteraction, longPressEnabled) {
-          detectTapGestures(
+          detectTapGesturesWithoutConsume(
+            onTap = { onInteraction(Interaction.Tap(it.toPoint())) },
             onLongPress =
               if (longPressEnabled) {
                 { onInteraction(Interaction.LongPress(it.toPoint())) }
               } else {
                 null
               },
-            onTap = { onInteraction(Interaction.Tap(it.toPoint())) },
           )
         }
       } else {
@@ -110,5 +118,39 @@ internal fun Modifier.pointerInput(
       }
     )
     .extraPointerInput(scrollState)
+
+private suspend fun PointerInputScope.detectTapGesturesWithoutConsume(
+  onTap: (Offset) -> Unit,
+  onLongPress: ((Offset) -> Unit)?,
+) {
+  awaitEachGesture {
+    val down = awaitFirstDown()
+    if (onLongPress != null) {
+      val longPress = awaitLongPressOrCancellation(down.id)
+      if (longPress != null) {
+        onLongPress(longPress.position)
+        return@awaitEachGesture
+      }
+    } else {
+      waitForUpOrCancellation()
+    }
+    val inputChange = currentEvent.changes.firstOrNull()
+    if (inputChange.isTap(down)) {
+      onTap(inputChange.position)
+    }
+  }
+}
+
+@OptIn(ExperimentalContracts::class)
+context(pointerEventScope: AwaitPointerEventScope)
+private fun PointerInputChange?.isTap(firstDown: PointerInputChange): Boolean {
+  contract { returns(true).implies(this@isTap != null) }
+  this ?: return false
+  val longPressTimeoutMillis = pointerEventScope.viewConfiguration.longPressTimeoutMillis
+  val touchSlop = pointerEventScope.viewConfiguration.touchSlop
+  val isNotLongPress = previousUptimeMillis - uptimeMillis < longPressTimeoutMillis
+  val isNotMove = (firstDown.position - position).getDistance() < touchSlop
+  return !pressed && previousPressed && isNotLongPress && isNotMove
+}
 
 private fun Offset.fits(size: IntSize) = x >= 0f && x <= size.width && y >= 0f && y <= size.height


### PR DESCRIPTION
`androidx.compose.foundation.gestures.detectTapGestures` used for detecting tap and long press interactions has caused an excessive `PointerInputChange` consumption leading to other `detectTapGestures` higher up the `Modifier` chain to be non functional. 

This resolves #1391.

## Interactions whose handling changes

The `onInteraction` callback signature changes from `(Interaction) -> Unit` to `(Interaction) -> Boolean`. The return value indicates whether the event was handled and its `PointerInputChange` should be consumed. In `CartesianChartHostImpl`, this returns `true` when `MarkerController.shouldAcceptInteraction` accepts the interaction, and `false` otherwise.

- **Tap** — Previously detected via `androidx.compose.foundation.gestures.detectTapGestures`, which unconditionally consumed pointer input. Now uses a custom implementation (`awaitFirstDown` + `waitForUpOrCancellation`) that only consumes the `PointerInputChange` when `onInteraction` returns `true`.
- **LongPress** — Same as Tap: replaces `detectTapGestures` with a custom implementation (`awaitLongPressOrCancellation`) that conditionally consumes based on the `onInteraction` return value.
- **Press** — Never consumed (`false` from the consumption check).
- **Release** — Never consumed (`false` from the consumption check).
- **Move** — Consumed only when `consumeMoveEvents && !scrollState.scrollEnabled` (previously consumed via `PointerInputChange.consume()` under the same condition, but inline rather than via the unified `consume` flag).
- **Enter** — Consumed based on the `onInteraction` return value.
- **Exit** — Consumed based on the `onInteraction` return value.
- **Scroll (Zoom)** — Always consumes all pointer changes when zoom fires.