### PR TITLE
Apply snapped auto-scroll before first draw on model growth

### DIFF
--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -253,7 +253,9 @@ internal fun CartesianChartHostImpl(
     scrollState.update(measuringContext.value, chart.layerBounds, layerDimensions)
 
     if (model != lastHandledModel) {
-      coroutineScope.launch { scrollState.autoScroll(model, previousModel) }
+      if (!scrollState.autoScrollBeforeFirstDraw(model, previousModel)) {
+        coroutineScope.launch { scrollState.autoScroll(model, previousModel) }
+      }
       lastHandledModel = model
     }
 

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -17,6 +17,7 @@
 package com.patrykandpatrick.vico.compose.cartesian
 
 import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.SnapSpec
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.gestures.ScrollableState
@@ -160,6 +161,16 @@ public class VicoScrollState {
       value = initialScroll.getValue(context, layerDimensions, bounds, maxValue)
       initialScrollHandled = true
     }
+  }
+
+  internal fun autoScrollBeforeFirstDraw(model: CartesianChartModel, oldModel: CartesianChartModel?): Boolean {
+    if (autoScrollAnimationSpec !is SnapSpec<*> || !autoScrollCondition.shouldScroll(oldModel, model)) {
+      return false
+    }
+    withUpdated { context, layerDimensions, bounds ->
+      value += autoScroll.getDelta(context, layerDimensions, bounds, maxValue, value)
+    }
+    return true
   }
 
   internal suspend fun autoScroll(model: CartesianChartModel, oldModel: CartesianChartModel?) {


### PR DESCRIPTION
## Summary

This PR proposes one possible fix for #1426.

In Compose `CartesianChartHost`, when a chart model grows and auto-scroll is configured to snap to the end, the new model can currently render once at the previous scroll offset before the auto-scroll coroutine runs. In single-page -> backfilled-history transitions, that can produce a visible one-frame jump.

This change adds a synchronous fast path for snapped auto-scroll:
- if `autoScrollAnimationSpec` is a `SnapSpec`
- and `autoScrollCondition` says the new model should scroll

then the scroll delta is applied immediately before the first draw of the new model.

For non-snap cases, the existing asynchronous path is preserved.

## Why this change

Today, `CartesianChartHost` updates the model and layout state first, then launches `scrollState.autoScroll(...)` in a coroutine. That separation is reasonable for animated scrolling, but for snapped scrolling it leaves a stale-frame window where the chart can briefly draw at the wrong viewport.

This PR narrows the fix to the snapped case only. It keeps the current behavior for animated auto-scroll, while avoiding the stale first frame for `Scroll.Absolute.End`-style updates.

## Scope

- Compose module only
- no public API changes
- no change to animated auto-scroll behavior
- fixes one specific timing issue around snapped auto-scroll

## Testing

- verified against a standalone repro that simulates a cached trailing page being replaced by a wider historical model through the same `CartesianChartModelProducer`

Standalone repro:
https://github.com/bcapps/vico/tree/repro/backfill-transition-sample/repros/vico-backfill-repro

## Notes

This is just one possible fix, but let me know if it's too specific for this use case.
