### PR TITLE
Fix: instantaneous scrolling for 0-duration `VicoScrollState` animations

### DIFF
--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.compose.cartesian
+
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.MonotonicFrameClock
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.LayoutDirection
+import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartRanges
+import com.patrykandpatrick.vico.compose.cartesian.layer.MutableCartesianLayerDimensions
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.junit.jupiter.api.Timeout
+
+@Timeout(1)
+class VicoScrollStateTest {
+  @MockK private lateinit var context: CartesianMeasuringContext
+  @MockK private lateinit var ranges: CartesianChartRanges
+
+  @BeforeTest
+  fun setUp() {
+    MockKAnnotations.init(this, relaxed = true)
+    every { context.layoutDirection } returns LayoutDirection.Ltr
+    every { context.ranges } returns ranges
+    every { ranges.minX } returns 0.0
+    every { ranges.maxX } returns 10.0
+    every { ranges.xLength } returns 10.0
+    every { ranges.xStep } returns 1.0
+  }
+
+  @Test
+  fun `When animateScroll uses zero-duration animation, then it updates the value immediately`() =
+    runBlocking(SuspendingFrameClock()) {
+      val frameClock = coroutineContext[MonotonicFrameClock] as SuspendingFrameClock
+      val sut = createScrollState()
+      val targetValue = 30f
+
+      sut.animateScroll(Scroll.Absolute.pixels(targetValue), tween(durationMillis = 0))
+
+      assertEquals(targetValue, sut.value)
+      assertEquals(0, frameClock.frameRequests)
+    }
+
+  @Test
+  fun `When animateScroll uses non-zero-duration animation, then it does not update the value immediately`() =
+    runBlocking(SuspendingFrameClock()) {
+      val frameClock = coroutineContext[MonotonicFrameClock] as SuspendingFrameClock
+      val sut = createScrollState()
+      val targetValue = 30f
+
+      val job =
+        launch(start = CoroutineStart.UNDISPATCHED) {
+          sut.animateScroll(Scroll.Absolute.pixels(targetValue), tween(durationMillis = 1))
+        }
+
+      assertEquals(0f, sut.value)
+      assertFalse(job.isCompleted)
+      assertEquals(1, frameClock.frameRequests)
+
+      job.cancelAndJoin()
+    }
+
+  private fun createScrollState(): VicoScrollState =
+    VicoScrollState(
+        scrollEnabled = true,
+        initialScroll = Scroll.Absolute.Start,
+        autoScroll = Scroll.Absolute.Start,
+        autoScrollCondition = AutoScrollCondition.Never,
+        autoScrollAnimationSpec = tween(),
+      )
+      .also {
+        it.update(
+          context = context,
+          bounds = Rect(0f, 0f, 100f, 100f),
+          layerDimensions = MutableCartesianLayerDimensions(xSpacing = 20f),
+        )
+        it.maxValue = 100f
+      }
+
+  private class SuspendingFrameClock : MonotonicFrameClock {
+    var frameRequests: Int = 0
+
+    override val key: CoroutineContext.Key<*>
+      get() = MonotonicFrameClock.Key
+
+    override suspend fun <R> withFrameNanos(onFrame: (Long) -> R): R {
+      frameRequests++
+      return suspendCancellableCoroutine {}
+    }
+  }
+}

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -32,7 +32,7 @@ import com.patrykandpatrick.vico.compose.common.*
 import com.patrykandpatrick.vico.compose.common.Defaults.CHART_HEIGHT
 import com.patrykandpatrick.vico.compose.common.data.ExtraStore
 import kotlin.math.abs
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 
@@ -140,7 +140,7 @@ internal fun CartesianChartHostImpl(
       markerSeriesIndex = markerSeriesIndex,
     )
 
-  val coroutineScope = rememberCoroutineScope { Dispatchers.Main.immediate }
+  val coroutineScope = rememberCoroutineScope()
   var lastHandledModel by remember { ValueWrapper(model) }
   val layerDimensions = remember { MutableCartesianLayerDimensions() }
 
@@ -254,7 +254,9 @@ internal fun CartesianChartHostImpl(
     scrollState.update(measuringContext.value, chart.layerBounds, layerDimensions)
 
     if (model != lastHandledModel) {
-      coroutineScope.launch { scrollState.autoScroll(model, previousModel) }
+      coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        scrollState.autoScroll(model, previousModel)
+      }
       lastHandledModel = model
     }
 

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -32,6 +32,7 @@ import com.patrykandpatrick.vico.compose.common.*
 import com.patrykandpatrick.vico.compose.common.Defaults.CHART_HEIGHT
 import com.patrykandpatrick.vico.compose.common.data.ExtraStore
 import kotlin.math.abs
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 
@@ -139,7 +140,7 @@ internal fun CartesianChartHostImpl(
       markerSeriesIndex = markerSeriesIndex,
     )
 
-  val coroutineScope = rememberCoroutineScope()
+  val coroutineScope = rememberCoroutineScope { Dispatchers.Main.immediate }
   var lastHandledModel by remember { ValueWrapper(model) }
   val layerDimensions = remember { MutableCartesianLayerDimensions() }
 

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -49,7 +49,6 @@ public class VicoScrollState {
   private val autoScroll: Scroll
   private val autoScrollCondition: AutoScrollCondition
   private val autoScrollAnimationSpec: AnimationSpec<Float>
-  private val vectorizedAutoScrollAnimationSpec: VectorizedAnimationSpec<AnimationVector1D>
   private val _value: MutableFloatState
   private val _maxValue = mutableFloatStateOf(0f)
   private var initialScrollHandled: Boolean
@@ -106,8 +105,6 @@ public class VicoScrollState {
     this.autoScroll = autoScroll
     this.autoScrollCondition = autoScrollCondition
     this.autoScrollAnimationSpec = autoScrollAnimationSpec
-    this.vectorizedAutoScrollAnimationSpec =
-      autoScrollAnimationSpec.vectorize(Float.VectorConverter)
     _value = mutableFloatStateOf(value)
     this.initialScrollHandled = initialScrollHandled
   }
@@ -198,13 +195,15 @@ public class VicoScrollState {
     withUpdated { context, layerDimensions, bounds ->
       val delta = scroll.getDelta(context, layerDimensions, bounds, maxValue, value)
       val duration =
-        vectorizedAutoScrollAnimationSpec.getDurationNanos(
-          initialValue = AnimationVector(value),
-          targetValue = AnimationVector(value + delta),
-          initialVelocity = AnimationVector(0f),
-        )
+        animationSpec
+          .vectorize(Float.VectorConverter)
+          .getDurationNanos(
+            initialValue = AnimationVector(value),
+            targetValue = AnimationVector(value + delta),
+            initialVelocity = AnimationVector(0f),
+          )
       if (duration == 0L) {
-        value += delta
+        scrollableState.scrollBy(delta)
       } else {
         scrollableState.animateScrollBy(delta, animationSpec)
       }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -16,8 +16,7 @@
 
 package com.patrykandpatrick.vico.compose.cartesian
 
-import androidx.compose.animation.core.AnimationSpec
-import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.*
 import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.gestures.animateScrollBy
@@ -50,6 +49,7 @@ public class VicoScrollState {
   private val autoScroll: Scroll
   private val autoScrollCondition: AutoScrollCondition
   private val autoScrollAnimationSpec: AnimationSpec<Float>
+  private val vectorizedAutoScrollAnimationSpec: VectorizedAnimationSpec<AnimationVector1D>
   private val _value: MutableFloatState
   private val _maxValue = mutableFloatStateOf(0f)
   private var initialScrollHandled: Boolean
@@ -106,6 +106,8 @@ public class VicoScrollState {
     this.autoScroll = autoScroll
     this.autoScrollCondition = autoScrollCondition
     this.autoScrollAnimationSpec = autoScrollAnimationSpec
+    this.vectorizedAutoScrollAnimationSpec =
+      autoScrollAnimationSpec.vectorize(Float.VectorConverter)
     _value = mutableFloatStateOf(value)
     this.initialScrollHandled = initialScrollHandled
   }
@@ -194,10 +196,18 @@ public class VicoScrollState {
   /** Triggers an animated scroll. */
   public suspend fun animateScroll(scroll: Scroll, animationSpec: AnimationSpec<Float> = spring()) {
     withUpdated { context, layerDimensions, bounds ->
-      scrollableState.animateScrollBy(
-        scroll.getDelta(context, layerDimensions, bounds, maxValue, value),
-        animationSpec,
-      )
+      val delta = scroll.getDelta(context, layerDimensions, bounds, maxValue, value)
+      val duration =
+        vectorizedAutoScrollAnimationSpec.getDurationNanos(
+          initialValue = AnimationVector(value),
+          targetValue = AnimationVector(value + delta),
+          initialVelocity = AnimationVector(0f),
+        )
+      if (duration == 0L) {
+        value += delta
+      } else {
+        scrollableState.animateScrollBy(delta, animationSpec)
+      }
     }
   }
 


### PR DESCRIPTION
This ensures that `animateScroll` immediately updates the scroll value if the animation duration is zero, preventing potential hangs. Additionally, `CartesianChartHost` now uses `Dispatchers.Main.immediate` for its coroutine scope to improve responsiveness.

This resolves #1426.